### PR TITLE
Update site URL to ag.micorp.pro across project

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://your-domain.vercel.app",
+    url: "https://ag.micorp.pro",
     siteName: "AG Movies",
     title: "AG MOVIES - Stream Movies & TV Shows",
     description: "Your ultimate destination for streaming movies and TV shows. Watch the latest movies and TV series online in HD quality.",
@@ -56,7 +56,7 @@ export const metadata: Metadata = {
     google: "your-google-verification-code",
   },
   alternates: {
-    canonical: "https://your-domain.vercel.app",
+    canonical: "https://ag.micorp.pro",
   },
 }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import { MetadataRoute } from 'next'
 import { createClient } from '@/lib/supabase/server'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.vercel.app'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ag.micorp.pro'
   
   try {
     const supabase = await createClient()

--- a/components/seo/structured-data.tsx
+++ b/components/seo/structured-data.tsx
@@ -6,7 +6,7 @@ interface StructuredDataProps {
 }
 
 export function StructuredData({ type, data }: StructuredDataProps) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.vercel.app'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ag.micorp.pro'
   
   if (type === 'movie') {
     const movie = data as Movie

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import type { Movie, TVShow } from '@/lib/types'
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.vercel.app'
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ag.micorp.pro'
 const siteName = 'AG Movies'
 
 export function generateMovieMetadata(movie: Movie): Metadata {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://your-domain.vercel.app/sitemap.xml
+Sitemap: https://ag.micorp.pro/sitemap.xml
 
 # Disallow admin and API routes
 Disallow: /admin/


### PR DESCRIPTION
Replaced all instances of 'your-domain.vercel.app' with 'ag.micorp.pro' in metadata, SEO utilities, sitemap generation, structured data, and robots.txt to reflect the new production domain.