### PR TITLE
Shorten mobile navigation item labels

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -57,8 +57,8 @@ export function Navigation() {
   const mobileNavItems = [
     { href: "/", label: "Home", icon: Home },
     { href: "/movies", label: "Movies", icon: Film },
-    { href: "/tv-shows", label: "TV Shows", icon: Tv },
-    { href: "/coming-soon", label: "Coming Soon", icon: Clock },
+    { href: "/tv-shows", label: "Shows", icon: Tv },
+    { href: "/coming-soon", label: "Coming", icon: Clock },
     { href: "/watchlist", label: "My List", icon: Bookmark },
   ]
 


### PR DESCRIPTION
Updated the labels for 'TV Shows' and 'Coming Soon' to 'Shows' and 'Coming' respectively in the mobile navigation items for improved brevity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated mobile navigation labels for brevity: “TV Shows” is now “Shows” and “Coming Soon” is now “Coming.”
  - Improves readability and fit on smaller screens without altering destinations or icons.
  - Navigation behavior, active states, and routing remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->